### PR TITLE
Fixed Warden Deploy Point Bug

### DIFF
--- a/DarkDragonDeploy/DarkDragonDeploy.cs
+++ b/DarkDragonDeploy/DarkDragonDeploy.cs
@@ -746,7 +746,7 @@ namespace DarkDragonDeploy
             if (UserSettings.UseWarden && warden != null)
             {
                 Log.Info($"{Tag} Deploying Warden...");
-                foreach (var t in Deploy.AtPoint(warden, mainTarget.DeployRanged))
+                foreach (var t in Deploy.AtPoint(warden, mainTarget.DeployGrunts))
                     yield return t;
                 yield return Rand.Int(500, 1000); //Wait
 

--- a/DarkDragonDeploy/Properties/AssemblyInfo.cs
+++ b/DarkDragonDeploy/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyFileVersion("1.0.0.2")]


### PR DESCRIPTION
There was a bug in the Deploy point for the warden. Was being set to an Empty location.  Fixed by having the warden deploy on the same point as the queen/king etc.